### PR TITLE
Avoid notices with PHP and more

### DIFF
--- a/src/test.php
+++ b/src/test.php
@@ -37,7 +37,7 @@ foreach(array(1,2,3) as $level){
             echo "SUCCESS\n";
           }else{
             echo "FAIL\n";
-            print_r($parser->sel);
+            print_r($parser->getSelector());
             echo "-expected:\n\n";
             echo $expected_output;
             echo "\n\n-actual:\n\n";


### PR DESCRIPTION
I have used this library, great! by the way, but i have had problems with notices from PHP interpreter. The constructor was old fashioned the new is  here. Using reserverd word var is not appropiate i prefer using word of visibility of property. I have uniquely done the method match public that is used for the selection. I removed some echos commented that are not big problem because of they were for debugging purpose i think.  And I have launched the test.php and all is ok but some selector is executed with other json file [[the selector was :expr(7 = x / 6)]] . It was so weird. 

Finally, I added some comments.

Regards
